### PR TITLE
Fixing tinymce.settings to work with ManifestStaticFilesStorage

### DIFF
--- a/tinymce/settings.py
+++ b/tinymce/settings.py
@@ -2,6 +2,8 @@ import os
 import warnings
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
+from django.utils.functional import lazy
+from utils import baseurl
 
 OLD_CONFIG = getattr(settings, 'TINYMCE_DEFAULT_CONFIG', False)
 if OLD_CONFIG:
@@ -10,9 +12,13 @@ DEFAULT_CONFIG = OLD_CONFIG or {'theme': "modern", 'relative_urls': False}
 
 if getattr(settings, 'TINYMCE_JS_URL', False):
     raise RuntimeError("TINYMCE_JS_URL is not supported anymore, check docs for instructions.")
-JS_URL = staticfiles_storage.url('tinymce/tinymce.min.js')
-JS_ROOT = staticfiles_storage.url('tinymce')
-JS_BASE_URL = JS_URL[:JS_URL.rfind('/')]
+
+# added laziness to support django.contrib.staticfiles.storage.ManifestStaticFilesStorage
+# and other storages that needs post-processing
+staticfiles_storage_url_lazy = lazy(staticfiles_storage.url, str)
+JS_URL = staticfiles_storage_url_lazy('tinymce/tinymce.min.js')
+JS_ROOT = staticfiles_storage_url_lazy('tinymce')
+JS_BASE_URL = lazy(baseurl, str)(JS_URL)
 
 if getattr(settings, 'TINYMCE_SPELLCHECKER', False):
     raise NotImplementedError("TINYMCE_SPELLCHECKER is not implemented yet.")

--- a/tinymce/utils.py
+++ b/tinymce/utils.py
@@ -1,3 +1,7 @@
+def baseurl(url):
+    return url[:url.rfind('/')]
+
+
 def is_installed(settings):
     """
     Check Django settings and verify that tinymce application is included


### PR DESCRIPTION
Adding lazines to static_file storage paths to make it work with [ManifestStaticFilesStorage](https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#manifeststaticfilesstorage).

Any idea how to properly test it?

Without laziness, there was errors like:

``` bash
(modalyst)modalyst@dtest4:~/modalyst$ ./manage.py collectstatic
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/modalyst/.virtualenvs/modalyst/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/home/modalyst/.virtualenvs/modalyst/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 328, in execute
    django.setup()
  File "/home/modalyst/.virtualenvs/modalyst/local/lib/python2.7/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/modalyst/.virtualenvs/modalyst/local/lib/python2.7/site-packages/django/apps/registry.py", line 108, in populate
    app_config.import_models(all_models)
  File "/home/modalyst/.virtualenvs/modalyst/local/lib/python2.7/site-packages/django/apps/config.py", line 198, in import_models
    self.models_module = import_module(models_module_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/modalyst/.virtualenvs/modalyst/local/lib/python2.7/site-packages/tinymce/models.py", line 6, in <module>
    from tinymce import widgets as tinymce_widgets
  File "/home/modalyst/.virtualenvs/modalyst/local/lib/python2.7/site-packages/tinymce/widgets.py", line 26, in <module>
    import tinymce.settings
  File "/home/modalyst/.virtualenvs/modalyst/local/lib/python2.7/site-packages/tinymce/settings.py", line 14, in <module>
    JS_ROOT = staticfiles_storage.url('tinymce')
  File "/home/modalyst/.virtualenvs/modalyst/local/lib/python2.7/site-packages/django/contrib/staticfiles/storage.py", line 131, in url
    hashed_name = self.stored_name(clean_name)
  File "/home/modalyst/.virtualenvs/modalyst/local/lib/python2.7/site-packages/django/contrib/staticfiles/storage.py", line 280, in stored_name
    cache_name = self.clean_name(self.hashed_name(name))
  File "/home/modalyst/.virtualenvs/modalyst/local/lib/python2.7/site-packages/django/contrib/staticfiles/storage.py", line 94, in hashed_name
    (clean_name, self))
ValueError: The file 'tinymce' could not be found with <django.contrib.staticfiles.storage.ManifestStaticFilesStorage object at 0x2d32690>.
```
